### PR TITLE
Handle self-closing subfield tag

### DIFF
--- a/marcalyx/marcalyx.py
+++ b/marcalyx/marcalyx.py
@@ -194,7 +194,7 @@ class DataField(MarcNamespacedElement):
 class SubField:
     def __init__(self, node):
         self.code = node.attrib['code']
-        self.value = node.text
+        self.value = node.text if node.text else ''
 
     def __repr__(self):
         return "$%s%s" % (self.code, self.value,)

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -59,6 +59,13 @@ def fissures():
     return marcalyx.Record(root)
 
 
+@pytest.fixture()
+def tokio():
+    tree = ET.parse('tests/xml/26003.xml')
+    root = tree.getroot()
+    return marcalyx.Record(root)
+
+
 def test_leader(kindred):
     assert kindred.leader == '00000cam a2200000Mi 4500'
 
@@ -83,6 +90,13 @@ def test_subfields_when_all_should_be_empy(kindred):
     s = kindred.subfield("650", "9")
     assert isinstance(s, list)
     assert len(s) == 0
+
+
+def test_self_closing_subfield(tokio):
+    es = tokio.subfield("520", "a")
+    assert isinstance(es, list)
+    assert len(es) == 1
+    assert str(es[0]) == '$a'
 
 
 def test_getting_a_field(kindred):

--- a/tests/xml/26003.xml
+++ b/tests/xml/26003.xml
@@ -1,0 +1,46 @@
+<record xmlns="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
+    <leader> nam 22 3u </leader>
+    <controlfield tag="001">26003</controlfield>
+    <controlfield tag="005">20190206</controlfield>
+    <controlfield tag="007">cuuuu---auuuu</controlfield>
+    <controlfield tag="008">190206s|||| xx o 0 u ||| |</controlfield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">9783486702866</subfield>
+    </datafield>
+    <datafield tag="100" ind1="1" ind2=" ">
+        <subfield code="a">Kittel, Manfred</subfield>
+        <subfield code="4">aut</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2=" ">
+        <subfield code="a">Nach Nürnberg und Tokio. Vergangenheitsbewältigung in Japan und Westdeutschland 1945 bis 1968</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+        <subfield code="b">De Gruyter</subfield>
+        <subfield code="c">2004</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+        <subfield code="a">1 electronic resource (201 p.)</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+        <subfield code="a"/>
+    </datafield>
+    <datafield tag="546" ind1=" " ind2=" ">
+        <subfield code="a">German</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+        <subfield code="a">History of Germany</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+        <subfield code="a">Modern history, 1453-</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+        <subfield code="a">Political science (General)</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2="0">
+        <subfield code="u">https://www.doabooks.org/doab?func=fulltext&amp;rid=26003</subfield>
+        <subfield code="z">Description of rights in Directory of Open Access Books (DOAB): Attribution Non-commercial No Derivatives (CC by-nc-nd)</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2="0">
+        <subfield code="u">https://doi.org/10.1524/9783486702866</subfield>
+    </datafield>
+</record>


### PR DESCRIPTION
If an empty (self-closing) tag is received, an error is currently thrown as it cannot parse the `None` value that lxml produces.

This update checks for a none value returned in the Subfield `__init__` and replaces it with an empty string if found.

It's unclear to me if a field with a single empty subfield really should be in a MARCXML record, but that is (unfortunately) not something that can be controlled for. I'm also unsure if an empty string is the best way to handle this, but it does have the benefit of being simple and therefore shouldn't have any side effects.

This commit also includes a new test with a new XML file that includes a `520` field that contains this case.