### PR TITLE
Skip fields with no subfields (or only empty subfields)

### DIFF
--- a/marcalyx/marcalyx.py
+++ b/marcalyx/marcalyx.py
@@ -38,10 +38,11 @@ class Record(MarcNamespacedElement):
         ns = self.get_namespace(node)
 
         self.leader = self.get_leader(node, ns)
-        self.fields = [ControlField(f) for f in
-                       self.find_control(node, ns)] + \
-                      [DataField(f, ns) for f in self.find_data(node, ns)]
-
+        self.fields = list(filter(None,
+            [ControlField(f) for f in self.find_control(node, ns)] + \
+            [DataField(f, ns) for f in self.find_data(node, ns)]
+        ))
+        
     def find_control(self, node, ns):
         return self.find_with_ns(node, 'controlfield', ns)
 
@@ -171,9 +172,13 @@ class DataField(MarcNamespacedElement):
         self.tag = node.attrib['tag']
         self.ind1 = node.attrib['ind1']
         self.ind2 = node.attrib['ind2']
-        self.subfields = [SubField(s) for s in
-                          self.find_with_ns(node, 'subfield', ns)]
-        self.value = ' '.join([s.value for s in self.subfields])
+        self.subfields = [
+            SubField(s) for s in
+            self.find_with_ns(node, 'subfield', ns)
+            if s.text is not None
+        ]
+        self.value = ' '.join([s.value for s in self.subfields]) \
+                      if len(self.subfields) > 0 else None
 
     def subfield(self, code):
         return [s for s in self.subfields if s.code == code]

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -59,6 +59,14 @@ def fissures():
     return marcalyx.Record(root)
 
 
+@pytest.fixture()
+def tokio():
+    tree = ET.parse('tests/xml/26003.xml')
+    root = tree.getroot()
+    return marcalyx.Record(root)
+
+
+
 def test_leader(kindred):
     assert kindred.leader == '00000cam a2200000Mi 4500'
 
@@ -83,6 +91,12 @@ def test_subfields_when_all_should_be_empy(kindred):
     s = kindred.subfield("650", "9")
     assert isinstance(s, list)
     assert len(s) == 0
+
+
+def test_self_closing_subfield(tokio):
+    es = tokio.subfield("520", "a")
+    assert isinstance(es, list)
+    assert len(es) == 0
 
 
 def test_getting_a_field(kindred):

--- a/tests/xml/26003.xml
+++ b/tests/xml/26003.xml
@@ -1,0 +1,46 @@
+<record xmlns="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
+    <leader> nam 22 3u </leader>
+    <controlfield tag="001">26003</controlfield>
+    <controlfield tag="005">20190206</controlfield>
+    <controlfield tag="007">cuuuu---auuuu</controlfield>
+    <controlfield tag="008">190206s|||| xx o 0 u ||| |</controlfield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">9783486702866</subfield>
+    </datafield>
+    <datafield tag="100" ind1="1" ind2=" ">
+        <subfield code="a">Kittel, Manfred</subfield>
+        <subfield code="4">aut</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2=" ">
+        <subfield code="a">Nach Nürnberg und Tokio. Vergangenheitsbewältigung in Japan und Westdeutschland 1945 bis 1968</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+        <subfield code="b">De Gruyter</subfield>
+        <subfield code="c">2004</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+        <subfield code="a">1 electronic resource (201 p.)</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+        <subfield code="a"/>
+    </datafield>
+    <datafield tag="546" ind1=" " ind2=" ">
+        <subfield code="a">German</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+        <subfield code="a">History of Germany</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+        <subfield code="a">Modern history, 1453-</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+        <subfield code="a">Political science (General)</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2="0">
+        <subfield code="u">https://www.doabooks.org/doab?func=fulltext&amp;rid=26003</subfield>
+        <subfield code="z">Description of rights in Directory of Open Access Books (DOAB): Attribution Non-commercial No Derivatives (CC by-nc-nd)</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2="0">
+        <subfield code="u">https://doi.org/10.1524/9783486702866</subfield>
+    </datafield>
+</record>


### PR DESCRIPTION
This is a follow on to PR #1 which fixed the issue of self-closing subfield tags by interpreting them as an empty string. After discussion it was decided that these are better modeled as containing `None` and being filtered out from future use, as they are functionally the same as a non-existent tag.

This handles them as `None` values, checking for `None` in subfields and filtering out any subfields that meet the criteria and then subsequently filtering out any fields that contain no subfields.

This relies on catching several `None` values and then applying a filter in the `Record` class that removes any `DataField`s that have evaluated to `None`.

The test case has been retained from PR #1 but now expects the request to evaluate to an empty list.